### PR TITLE
Remove requireUser from refresh endpoint

### DIFF
--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -5,7 +5,6 @@ import {
   invalidateSessionHandler,
   refreshAccessTokenHandler,
 } from "@controller/authController";
-import requireUser from "@middleware/requireUser";
 import validateResource from "@middleware/validateResource";
 import { createSessionSchema } from "@schema/authSchema";
 
@@ -19,6 +18,6 @@ authRouter.post(
 
 authRouter.post("/sessions/invalidate", invalidateSessionHandler);
 
-authRouter.post("/sessions/refresh", requireUser, refreshAccessTokenHandler);
+authRouter.post("/sessions/refresh", refreshAccessTokenHandler);
 
 export default authRouter;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Changes
The idea of refresh tokens is to create a new access token when it is invalid. However the `requireUser` middleware checks to see if an accessToken is provided and it is valid. If it is not valid, the refresh would not go through. This PR fixes this by removing the check.

<!-- Describe your changes in detail -->

## Screenshots (if appropriate)

<!--- If the PR includes UI changes, add screenshots/gifs/videos to show the result. -->

## Test Steps

<!-- Add any test steps for reviewers to follow. -->

## Related PRs (if any)

<!-- Add links to any related PRs. -->
