### PR TITLE
Link token changes

### DIFF
--- a/prisma/migrations/20241127043316_plaid_user_token/migration.sql
+++ b/prisma/migrations/20241127043316_plaid_user_token/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "plaidUserToken" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   onboardingStatus OnboardingStatus @default(IN_PROGRESS)
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
+  plaidUserToken   String?
 
   account Account[]
 }

--- a/src/controller/plaidController.ts
+++ b/src/controller/plaidController.ts
@@ -20,7 +20,8 @@ export async function createLinkTokenHandler(req: Request, res: Response) {
     let userToken: string;
 
     if (userResponse.plaidUserToken) {
-      userToken = userResponse.plaidUserToken as string;
+      // todo: fix this weird eslint issue
+      userToken = userResponse.plaidUserToken;
     } else {
       const createPlaidUserResponse = await createPlaidUser(userId);
       userToken = createPlaidUserResponse.data.user_token;

--- a/src/service/plaidService.ts
+++ b/src/service/plaidService.ts
@@ -7,6 +7,7 @@ import {
   PlaidApi,
   PlaidEnvironments,
   Products,
+  UserCreateRequest,
 } from "plaid";
 
 const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID;
@@ -26,10 +27,11 @@ const configuration = new Configuration({
 
 const plaid = new PlaidApi(configuration);
 
-export async function createLinkToken(userId: string) {
+export async function createLinkToken(userToken: string, userId: string) {
   const products: Products[] = [Products.Assets, Products.Transactions];
   const country_codes: CountryCode[] = [CountryCode.Ca];
   const request: LinkTokenCreateRequest = {
+    user_token: userToken,
     user: {
       client_user_id: userId,
     },
@@ -41,6 +43,14 @@ export async function createLinkToken(userId: string) {
   };
 
   return await plaid.linkTokenCreate(request);
+}
+
+export async function createPlaidUser(userId: string) {
+  const request: UserCreateRequest = {
+    client_user_id: userId,
+  };
+
+  return await plaid.userCreate(request);
 }
 
 export async function exchangePublicToken(publicToken: string) {

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { hash } from "argon2";
 
 import prisma from "@prisma/index";
@@ -24,5 +25,19 @@ export async function findUserById(id: string) {
     where: {
       id,
     },
+  });
+}
+
+export async function updateUser(
+  userId: string,
+  updates: Partial<Prisma.UserUpdateInput>,
+) {
+  if (updates.password) {
+    updates.password = await hash(updates.password as string);
+  }
+
+  return await prisma.user.update({
+    where: { id: userId },
+    data: updates,
   });
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Changes
in a previous pr, I added this to the request of the `createLinkToken` fn:
```
enable_multi_item_link: true
```

I also did not read the documentation for the supporting changes required to enable multi item link so it exploded when it was implemented. shocker!!!

here is said documentation:
https://plaid.com/docs/link/multi-item-link/

tl;dr:
- Before creating a link token, a user needs to be created internally in Plaid. This can be done through the `/user/create` endpoint.
- Once a user has been created, a `user_token` is sent back in the response. This is a one time token that is used to access the Plaid user data, and will not be provided again. As a result, this needs to go into our DB.
- Using the `user_token` (either new or from our DB) it needs to be passed to the `link/token/create` to generate a link token.

Here is the updated flow of `createLinkTokenHandler`:
1. Check if the user has an existing plaid user token. If not, create on using the `createPlaidUser` service and update the user information using the `updateUser` service.
2. Pass the user token to the `createLinkToken` service.
3. Return the link token in the response.


<!-- Describe your changes in detail -->

## Screenshots (if appropriate)

<!--- If the PR includes UI changes, add screenshots/gifs/videos to show the result. -->

## Test Steps

<!-- Add any test steps for reviewers to follow. -->

## Related PRs (if any)

<!-- Add links to any related PRs. -->
