### PR TITLE
Create Item Logic

### DIFF
--- a/src/controllers/item/createItemHandler.ts
+++ b/src/controllers/item/createItemHandler.ts
@@ -1,0 +1,109 @@
+import { User } from "@prisma/client";
+import { Request, Response } from "express";
+
+import { CreateItemInput } from "@schema/itemSchema";
+import { createAccount } from "@services/account/createAccount";
+import { createItem } from "@services/item/createItem";
+import { getItem } from "@services/item/getItem";
+import { exchangePublicToken } from "@services/plaid/exchangePublicToken";
+import { getInstitutionById } from "@services/plaid/getInstitutionById";
+import { getPlaidAccounts } from "@services/plaid/getPlaidAccounts";
+import { getPlaidItem } from "@services/plaid/getPlaidItem";
+
+export async function createItemHandler(
+  req: Request<object, object, CreateItemInput>,
+  res: Response,
+) {
+  const user = res.locals.user as User;
+  const userId = user.id;
+
+  const { publicToken } = req.body;
+
+  try {
+    const exchangePublicTokenResponse = await exchangePublicToken(publicToken);
+    const accessToken = exchangePublicTokenResponse.data.access_token;
+
+    const getPlaidItemResponse = await getPlaidItem(accessToken);
+    const plaidItem = getPlaidItemResponse.data.item;
+
+    const institutionId = plaidItem.institution_id;
+    let institutionName: string | undefined;
+
+    if (institutionId) {
+      // Check if item already exists in the database
+      const getItemResponse = await getItem(userId, { institutionId });
+      console.log(getItemResponse);
+
+      if (getItemResponse) {
+        res.status(409).json({
+          message: "Item already exists",
+          item: getItemResponse,
+        });
+        return;
+      }
+
+      // Add the institution name to the item
+      const institutionResponse = await getInstitutionById(institutionId);
+      institutionName = institutionResponse.data.institution.name;
+    }
+
+    const item = {
+      plaidId: plaidItem.item_id,
+      userId,
+      accessToken,
+      institutionId,
+      institutionName,
+    };
+
+    const createdItem = await createItem(item);
+
+    // Create accounts in the database at the same time to avoid orphaned items
+    const getPlaidAccountsResponse = await getPlaidAccounts(accessToken);
+    const plaidAccounts = getPlaidAccountsResponse.data.accounts;
+
+    const createdAccounts = [];
+
+    for (const plaidAccount of plaidAccounts) {
+      try {
+        const accountId = plaidAccount.account_id;
+        const account = {
+          id: accountId,
+          plaidId: plaidAccount.account_id,
+          itemId: createdItem.id,
+          mask: plaidAccount.mask,
+          name: plaidAccount.name,
+          officialName: plaidAccount.official_name,
+          type: plaidAccount.type,
+          subtype: plaidAccount.subtype,
+          availableBalance: plaidAccount.balances.available,
+          currentBalance: plaidAccount.balances.current,
+          limit: plaidAccount.balances.limit,
+          currencyCode:
+            plaidAccount.balances.iso_currency_code ??
+            plaidAccount.balances.unofficial_currency_code,
+        };
+
+        const newAccount = await createAccount(account);
+        createdAccounts.push(newAccount);
+      } catch (accountError) {
+        console.error({
+          message: `Failed to create account ${plaidAccount.account_id}:`,
+          accountError,
+        });
+        continue;
+      }
+    }
+
+    res.status(200).json({
+      message: "Item and accounts created successfully",
+      createdItem,
+      createdAccounts,
+    });
+  } catch (error) {
+    console.error("Unknown error creating item:", error);
+    res.status(500).json({
+      message: "Could not create item",
+      error: (error as Error).message,
+    });
+  }
+}

--- a/src/controllers/item/createItemHandler.ts
+++ b/src/controllers/item/createItemHandler.ts
@@ -31,8 +31,7 @@ export async function createItemHandler(
 
     if (institutionId) {
       // Check if item already exists in the database
-      const getItemResponse = await getItem(userId, { institutionId });
-      console.log(getItemResponse);
+      const getItemResponse = await getItem({ userId, institutionId });
 
       if (getItemResponse) {
         res.status(409).json({

--- a/src/controllers/item/getItemHandler.ts
+++ b/src/controllers/item/getItemHandler.ts
@@ -1,0 +1,20 @@
+import { User } from "@prisma/client";
+import { Request, Response } from "express";
+
+import { getItem } from "@services/item/getItem";
+
+export async function getItemHandler(req: Request, res: Response) {
+  const user = res.locals.user as User;
+  const filters = req.query;
+
+  try {
+    const item = await getItem(user.id, filters);
+    res.status(200).json(item);
+  } catch (error) {
+    console.error("Error fetching items:", error);
+    res.status(500).json({
+      message: "Could not fetch items",
+      error: (error as Error).message,
+    });
+  }
+}

--- a/src/controllers/item/getItemHandler.ts
+++ b/src/controllers/item/getItemHandler.ts
@@ -5,10 +5,12 @@ import { getItem } from "@services/item/getItem";
 
 export async function getItemHandler(req: Request, res: Response) {
   const user = res.locals.user as User;
+  const userId = user.id;
+
   const filters = req.query;
 
   try {
-    const item = await getItem(user.id, filters);
+    const item = await getItem({ userId, ...filters });
     res.status(200).json(item);
   } catch (error) {
     console.error("Error fetching items:", error);

--- a/src/routes/accountRoutes.ts
+++ b/src/routes/accountRoutes.ts
@@ -5,6 +5,6 @@ import requireUser from "@middleware/requireUser";
 
 const accountRouter = Router();
 
-accountRouter.get("/account", requireUser, getAccountsHandler);
+accountRouter.get("/accounts", requireUser, getAccountsHandler);
 
 export default accountRouter;

--- a/src/routes/accountRoutes.ts
+++ b/src/routes/accountRoutes.ts
@@ -5,6 +5,6 @@ import requireUser from "@middleware/requireUser";
 
 const accountRouter = Router();
 
-accountRouter.get("/accounts", requireUser, getAccountsHandler);
+accountRouter.get("/account", requireUser, getAccountsHandler);
 
 export default accountRouter;

--- a/src/routes/itemRoutes.ts
+++ b/src/routes/itemRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+
+import { createItemHandler } from "@controllers/item/createItemHandler";
+import { getItemHandler } from "@controllers/item/getItemHandler";
+import requireUser from "@middleware/requireUser";
+
+const itemRouter = Router();
+
+itemRouter.post("/item", requireUser, createItemHandler);
+
+itemRouter.get("/item", requireUser, getItemHandler);
+
+export default itemRouter;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 
+import itemRouter from "@routes//itemRoutes";
 import accountRouter from "@routes/accountRoutes";
 import authRouter from "@routes/authRoutes";
 import plaidRouter from "@routes/plaidRoutes";
@@ -13,6 +14,7 @@ router.get("/healthcheck", (req, res) => {
 
 router.use(accountRouter);
 router.use(authRouter);
+router.use(itemRouter);
 router.use(plaidRouter);
 router.use(userRouter);
 

--- a/src/schema/itemSchema.ts
+++ b/src/schema/itemSchema.ts
@@ -1,0 +1,11 @@
+import { TypeOf, object, string } from "zod";
+
+export type CreateItemInput = TypeOf<typeof createItemSchema>["body"];
+
+export const createItemSchema = object({
+  body: object({
+    publicToken: string({
+      required_error: "Public token is required",
+    }),
+  }),
+});

--- a/src/services/item/createItem.ts
+++ b/src/services/item/createItem.ts
@@ -1,0 +1,17 @@
+import prisma from "@prisma/index";
+
+interface CreateItem {
+  plaidId: string;
+  userId: string;
+  accessToken: string;
+  institutionId?: string | null;
+  institutionName?: string | null;
+}
+
+export async function createItem(item: CreateItem) {
+  return await prisma.item.create({
+    data: {
+      ...item,
+    },
+  });
+}

--- a/src/services/item/getItem.ts
+++ b/src/services/item/getItem.ts
@@ -1,11 +1,12 @@
 import prisma from "@prisma/index";
 
 export type GetItemsFilters = {
+  userId: string;
   institutionId?: string;
 };
 
-export async function getItem(userId: string, filters: GetItemsFilters) {
-  const { institutionId } = filters;
+export async function getItem(filters: GetItemsFilters) {
+  const { userId, institutionId } = filters;
 
   return await prisma.item.findFirst({
     where: {

--- a/src/services/item/getItem.ts
+++ b/src/services/item/getItem.ts
@@ -1,0 +1,16 @@
+import prisma from "@prisma/index";
+
+export type GetItemsFilters = {
+  institutionId?: string;
+};
+
+export async function getItem(userId: string, filters: GetItemsFilters) {
+  const { institutionId } = filters;
+
+  return await prisma.item.findFirst({
+    where: {
+      userId,
+      institutionId,
+    },
+  });
+}

--- a/src/services/plaid/createLinkToken.ts
+++ b/src/services/plaid/createLinkToken.ts
@@ -11,7 +11,6 @@ export async function createLinkToken(userToken: string, userId: string) {
       client_user_id: userId,
     },
     client_name: "Opulus",
-    enable_multi_item_link: true,
     products,
     country_codes,
     language: "en",

--- a/src/services/plaid/getInstitutionById.ts
+++ b/src/services/plaid/getInstitutionById.ts
@@ -1,0 +1,13 @@
+import { CountryCode, InstitutionsGetByIdRequest } from "plaid";
+
+import { plaid } from "./plaid";
+
+// todo: this needs to receive its filters from query params
+export async function getInstitutionById(institutionId: string) {
+  const request: InstitutionsGetByIdRequest = {
+    institution_id: institutionId,
+    country_codes: [CountryCode.Ca],
+  };
+
+  return await plaid.institutionsGetById(request);
+}

--- a/src/services/plaid/getInstitutionById.ts
+++ b/src/services/plaid/getInstitutionById.ts
@@ -2,7 +2,6 @@ import { CountryCode, InstitutionsGetByIdRequest } from "plaid";
 
 import { plaid } from "./plaid";
 
-// todo: this needs to receive its filters from query params
 export async function getInstitutionById(institutionId: string) {
   const request: InstitutionsGetByIdRequest = {
     institution_id: institutionId,

--- a/src/services/plaid/getPlaidItem.ts
+++ b/src/services/plaid/getPlaidItem.ts
@@ -1,0 +1,11 @@
+import { AccountsGetRequest } from "plaid";
+
+import { plaid } from "./plaid";
+
+export async function getPlaidItem(accessToken: string) {
+  const request: AccountsGetRequest = {
+    access_token: accessToken,
+  };
+
+  return await plaid.itemGet(request);
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Changes
This PR adds a new handler, `createItemHandler`, that will write the data provided by Plaid on the `Item` and `Account` into our database when a user links their accounts. In-line comments for more context on specific changes.

Note this PR is being merged into `saf/database-refactor`. #18 will need to be merged into `main` first, then this branch will need to rebase `main`. 

Why did I do this? Its a neat trick to be able to use dependent changes from another branch, while keeping this PR easier to read. For example, I need the new definitions created for `Items` in the database to be able to write to them in this PR, but notice that the schema file doesn't appear in the Files Changed section.

<!-- Describe your changes in detail -->

## Screenshots (if appropriate)

<!--- If the PR includes UI changes, add screenshots/gifs/videos to show the result. -->

## Test Steps

<!-- Add any test steps for reviewers to follow. -->

## Related PRs (if any)

<!-- Add links to any related PRs. -->
