### PR TITLE
Transactions Sync Fix

### DIFF
--- a/prisma/migrations/20250217004144_transaction_cursor/migration.sql
+++ b/prisma/migrations/20250217004144_transaction_cursor/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `transactionCursor` to the `Item` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "transactionCursor" TEXT NOT NULL;

--- a/prisma/migrations/20250217014609_fix_id_issue/migration.sql
+++ b/prisma/migrations/20250217014609_fix_id_issue/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Transaction" DROP CONSTRAINT "Transaction_accountId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("plaidId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250217211146_optional_cursor/migration.sql
+++ b/prisma/migrations/20250217211146_optional_cursor/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Account" DROP CONSTRAINT "Account_itemId_fkey";
+
+-- AlterTable
+ALTER TABLE "Item" ALTER COLUMN "transactionCursor" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("plaidId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,7 @@ model Item {
   accessToken      String
   institutionId    String?
   institutionName  String?
-  transactionCursor String
+  transactionCursor String?
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @default(now())
 
@@ -69,7 +69,7 @@ model Account {
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @default(now())
 
-  item             Item             @relation(fields: [itemId], references: [id])
+  item             Item             @relation(fields: [itemId], references: [plaidId])
   transactions     Transaction[]
 }
 
@@ -96,5 +96,5 @@ model Transaction {
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @default(now())
 
-  account         Account          @relation(fields: [accountId], references: [id])
+  account         Account          @relation(fields: [accountId], references: [plaidId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model Item {
   accessToken      String
   institutionId    String?
   institutionName  String?
+  transactionCursor String
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @default(now())
 

--- a/src/controllers/item/createItemHandler.ts
+++ b/src/controllers/item/createItemHandler.ts
@@ -7,7 +7,6 @@ import { getLinkSession } from "@services/linkSession/getLinkSession";
 import { exchangePublicToken } from "@services/plaid/exchangePublicToken";
 import { getInstitutionById } from "@services/plaid/getInstitutionById";
 import { getPlaidItem } from "@services/plaid/getPlaidItem";
-import { transactionsSync } from "@services/plaid/transactionsSync";
 import { normalizeItem } from "@src/types/Item/normalizeItem";
 
 export async function createItemHandler(
@@ -66,19 +65,8 @@ export async function createItemHandler(
       institutionName = institutionResponse.data.institution.name;
     }
 
-    // To receive the SYNC_UPDATES_AVAILABLE webhook for an item, we need to sync transactions at least once
-    // Assume this first call returns an empty array since its immediately called after the item has been created
-    const transactionsSyncReponse = await transactionsSync(accessToken);
-    const transactionCursor = transactionsSyncReponse.data.next_cursor;
-
     // Create the Item
-    const item = normalizeItem(
-      plaidItem,
-      userId,
-      accessToken,
-      transactionCursor,
-      institutionName,
-    );
+    const item = normalizeItem(plaidItem, userId, accessToken, institutionName);
 
     try {
       await createItem(item);

--- a/src/controllers/item/createItemHandler.ts
+++ b/src/controllers/item/createItemHandler.ts
@@ -1,20 +1,14 @@
-import { Item } from "@prisma/client";
 import { Request, Response } from "express";
 
 import { WebhookInput } from "@schema/webhookSchema";
-import { createAccounts } from "@services/account/createAccounts";
 import { createItem } from "@services/item/createItem";
 import { getItem } from "@services/item/getItem";
 import { getLinkSession } from "@services/linkSession/getLinkSession";
 import { exchangePublicToken } from "@services/plaid/exchangePublicToken";
 import { getInstitutionById } from "@services/plaid/getInstitutionById";
-import { getPlaidAccounts } from "@services/plaid/getPlaidAccounts";
 import { getPlaidItem } from "@services/plaid/getPlaidItem";
 import { transactionsSync } from "@services/plaid/transactionsSync";
-import { createTransactions } from "@src/services/transaction/createTransactions";
-import { normalizeAccount } from "@src/types/Account/normalizeAccount";
 import { normalizeItem } from "@src/types/Item/normalizeItem";
-import { normalizeTransaction } from "@src/types/Transaction/normalizeTransaction";
 
 export async function createItemHandler(
   req: Request<object, object, WebhookInput>,
@@ -23,6 +17,7 @@ export async function createItemHandler(
   const {
     webhook_code: webhookCode,
     public_token: publicToken,
+    link_session_id: linkSessionId,
     link_token: linkToken,
   } = req.body;
 
@@ -71,60 +66,32 @@ export async function createItemHandler(
       institutionName = institutionResponse.data.institution.name;
     }
 
-    const normalizedItem = normalizeItem(
+    // To receive the SYNC_UPDATES_AVAILABLE webhook for an item, we need to sync transactions at least once
+    // Assume this first call returns an empty array since its immediately called after the item has been created
+    const transactionsSyncReponse = await transactionsSync(accessToken);
+    const transactionCursor = transactionsSyncReponse.data.next_cursor;
+
+    // Create the Item
+    const item = normalizeItem(
       plaidItem,
       userId,
       accessToken,
+      transactionCursor,
       institutionName,
     );
-    let item;
 
     try {
-      item = (await createItem(normalizedItem)) as Item;
+      await createItem(item);
     } catch (itemError) {
       throw new Error(`Failed to create item: ${(itemError as Error).message}`);
     }
 
-    // Create accounts in the database at the same time to avoid orphaned items
-    const getPlaidAccountsResponse = await getPlaidAccounts(accessToken);
-    const plaidAccounts = getPlaidAccountsResponse.data.accounts;
-
-    const accounts = plaidAccounts.map((plaidAccount) =>
-      normalizeAccount(item.id, plaidAccount),
-    );
-
-    try {
-      await createAccounts(accounts);
-    } catch (accountsError) {
-      console.error({
-        message: "Failed to create accounts",
-        accounts,
-        accountsError,
-      });
-    }
-
-    // To receive the SYNC_UPDATES_AVAILABLE webhook for an item, we need to sync transactions at least once
-    // Note: this first call might return an empty array since its immediately called after the item has been created
-    const transactionsSyncReponse = await transactionsSync(item.accessToken);
-    const plaidTransactions = transactionsSyncReponse.data.added;
-
-    const transactions = plaidTransactions.map((plaidTransaction) =>
-      normalizeTransaction(plaidTransaction),
-    );
-
-    try {
-      await createTransactions(transactions);
-    } catch (transactionsError) {
-      console.error({
-        message: "Failed to create transactions",
-        transactions,
-        transactionsError,
-      });
-    }
-
     console.log(
-      `${webhookCode} - ${plaidItem.item_id}: ${accounts.length} accounts added, ${3} transactions added`,
+      `[LINK WEBHOOK] ${webhookCode} - ${linkSessionId} - ${item.plaidId} created`,
     );
+
+    // I'm not actually sure if we need to return a response, or who we're responding to
+    // Should look into this
     res.status(200).json({
       message: "Item created successfully",
     });

--- a/src/controllers/transaction/syncTransactionsHandler.ts
+++ b/src/controllers/transaction/syncTransactionsHandler.ts
@@ -54,11 +54,6 @@ export async function syncTransactionsHandler(
 
     const { added, modified, removed, transactionCursor } = transactions;
 
-    // todo: some better error handling
-    if (!transactionCursor) {
-      throw new Error("Transaction cursor not found");
-    }
-
     // Update item with latest transactionCursor
     const updatedItem = {
       ...item,

--- a/src/controllers/transaction/syncTransactionsHandler.ts
+++ b/src/controllers/transaction/syncTransactionsHandler.ts
@@ -24,7 +24,6 @@ export async function syncTransactionsHandler(
     // Note: this error should typically never fire, because if the item doesn't exist in our database, it shouldn't exist in Plaid's database.
     // We need to call /item/remove to remove items from Plaid, and their related webhooks from firing.
     if (!item) {
-      console.error("Item not found");
       res.status(404).json({
         message: "Item not found",
       });

--- a/src/services/item/updateItem.ts
+++ b/src/services/item/updateItem.ts
@@ -1,0 +1,19 @@
+import { Prisma } from "@prisma/client";
+
+import prisma from "@prisma/index";
+import { Item } from "@src/types/Item/Item";
+
+export async function updateItem(item: Item) {
+  try {
+    return await prisma.item.update({
+      where: {
+        plaidId: item.plaidId,
+      },
+      data: item,
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new Error(error.message);
+    }
+  }
+}

--- a/src/services/plaid/createLinkToken.ts
+++ b/src/services/plaid/createLinkToken.ts
@@ -17,6 +17,9 @@ export async function createLinkToken(userToken: string, userId: string) {
     products,
     country_codes,
     language: "en",
+    transactions: {
+      days_requested: 730,
+    },
     webhook: `${WEBHOOK_URL}/webhook`,
   };
 

--- a/src/services/plaid/transactionsSync.ts
+++ b/src/services/plaid/transactionsSync.ts
@@ -1,11 +1,51 @@
-import { TransactionsSyncRequest } from "plaid";
+import {
+  RemovedTransaction,
+  Transaction,
+  TransactionsSyncRequest,
+} from "plaid";
 
 import { plaid } from "./plaid";
 
-export async function transactionsSync(accessToken: string) {
-  const request: TransactionsSyncRequest = {
-    access_token: accessToken,
-  };
+export async function transactionsSync(
+  accessToken: string,
+  cursor?: string,
+  retries: number = 3,
+) {
+  let added: Array<Transaction> = [];
+  let modified: Array<Transaction> = [];
+  let removed: Array<RemovedTransaction> = [];
+  let hasMore = true;
+  let transactionCursor = cursor;
 
-  return await plaid.transactionsSync(request);
+  try {
+    // Iterate through each page of new transaction updates for item
+    while (hasMore) {
+      const request: TransactionsSyncRequest = {
+        access_token: accessToken,
+        cursor: transactionCursor,
+      };
+
+      const transactions = await plaid.transactionsSync(request);
+
+      const data = transactions.data;
+
+      // Add this page of results
+      added = added.concat(data.added);
+      modified = modified.concat(data.modified);
+      removed = removed.concat(data.removed);
+
+      hasMore = data.has_more;
+      transactionCursor = data.next_cursor;
+    }
+  } catch (error) {
+    console.error(`Error fetching transactions: ${(error as Error).message}`);
+    if (retries > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for 1 second
+      return transactionsSync(accessToken, cursor, retries - 1);
+    } else {
+      throw error;
+    }
+  }
+
+  return { added, modified, removed, transactionCursor, accessToken };
 }

--- a/src/services/plaid/transactionsSync.ts
+++ b/src/services/plaid/transactionsSync.ts
@@ -23,6 +23,7 @@ export async function transactionsSync(
       const request: TransactionsSyncRequest = {
         access_token: accessToken,
         cursor: transactionCursor,
+        count: 500,
       };
 
       const transactions = await plaid.transactionsSync(request);

--- a/src/types/Item/Item.ts
+++ b/src/types/Item/Item.ts
@@ -2,6 +2,7 @@ export interface Item {
   plaidId: string;
   userId: string;
   accessToken: string;
+  transactionCursor: string;
   institutionId?: string | null;
   institutionName?: string | null;
 }

--- a/src/types/Item/Item.ts
+++ b/src/types/Item/Item.ts
@@ -2,7 +2,7 @@ export interface Item {
   plaidId: string;
   userId: string;
   accessToken: string;
-  transactionCursor: string;
   institutionId?: string | null;
   institutionName?: string | null;
+  transactionCursor?: string;
 }

--- a/src/types/Item/normalizeItem.ts
+++ b/src/types/Item/normalizeItem.ts
@@ -6,12 +6,14 @@ export function normalizeItem(
   item: PlaidItem,
   userId: string,
   accessToken: string,
+  transactionCursor: string,
   institutionName?: string,
 ): Item {
   return {
     plaidId: item.item_id,
     userId,
     accessToken,
+    transactionCursor,
     institutionId: item.institution_id,
     institutionName,
   };

--- a/src/types/Item/normalizeItem.ts
+++ b/src/types/Item/normalizeItem.ts
@@ -6,14 +6,12 @@ export function normalizeItem(
   item: PlaidItem,
   userId: string,
   accessToken: string,
-  transactionCursor: string,
   institutionName?: string,
 ): Item {
   return {
     plaidId: item.item_id,
     userId,
     accessToken,
-    transactionCursor,
     institutionId: item.institution_id,
     institutionName,
   };

--- a/src/webhook/handleTransactionsWebhook.ts
+++ b/src/webhook/handleTransactionsWebhook.ts
@@ -12,6 +12,7 @@ export async function handleTransactionsWebhook(
   console.log(`[TRANSACTIONS WEBHOOK] ${webhookCode} - ${plaidItemId}`);
 
   switch (webhookCode) {
+    case "INITIAL_UPDATE":
     case "SYNC_UPDATES_AVAILABLE": {
       await syncTransactionsHandler(req, res);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Changes
After successfully creating an Item, the `createItemHandler` would attempt to create the transactions by calling the `transactions/sync` endpoint on Plaid. I noticed this would cause a 400, as Plaid begins preparing transactions data when the Item is created, but the process can take anywhere from a few seconds to several minutes to complete, depending on the number of transactions available.

These changes move the sync transactions logic to when `INITIAL_UPDATE` is fired. This is done because when this webhook is fired, Plaid has the initial 30 days of transactions ready to pull. This verifies that a 400 is not thrown when attempting to pull transactions that do not exist.

I've also added pagination logic to the sync transactions logic. This includes adding a cursor to each Item in the database to track paginated updates.

Unrelated to the fix, but I've updated the foreign key relationships between Items and Accounts, and Accounts and Transactions to reference their Plaid ID instead our database ID. This is to keep relations consistent, as when we query data from Plaid, the id they reference is the Plaid ID. Referencing our ID for relationships made this more complex.

<!-- Describe your changes in detail -->

## Screenshots (if appropriate)

<!--- If the PR includes UI changes, add screenshots/gifs/videos to show the result. -->

## Test Steps

<!-- Add any test steps for reviewers to follow. -->

## Related PRs (if any)

<!-- Add links to any related PRs. -->
